### PR TITLE
Fix CI Workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -57,6 +57,9 @@ jobs:
         run: |-
           # enable ccache
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+
+          # make dxc executable
+          chmod +x src/contrib/dxc/bin/x64/dxc:
           
           cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_MAKE_PROGRAM=ninja -G Ninja -S . -B cmake-build
           cmake --build cmake-build --config Debug --target rt64 -j 8

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,7 +33,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build libsdl2-dev
+          sudo apt-get install -y ninja-build libsdl2-dev libgtk-3-dev
           
           # Install SDL2
           echo ::group::install SDL2

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -57,9 +57,6 @@ jobs:
         run: |-
           # enable ccache
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-
-          # make dxc executable
-          chmod +x src/contrib/dxc/bin/x64/dxc:
           
           cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_MAKE_PROGRAM=ninja -G Ninja -S . -B cmake-build
           cmake --build cmake-build --config Debug --target rt64 -j 8


### PR DESCRIPTION
Fixes CI workflows by installing missing dependency and updating dxc-bin as a fix that made the dxc binary executable was made later in the commit history.