### PR TITLE
Link against `Xrandr` on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,8 +350,8 @@ endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     find_package(X11 REQUIRED)
-    target_include_directories(rt64 PUBLIC ${X11_INCLUDE_DIR})
-    target_link_libraries(rt64 ${X11_LIBRARIES} Xrandr)
+    target_include_directories(rt64 PUBLIC ${X11_INCLUDE_DIR} ${X11_Xrandr_INCLUDE_PATH})
+    target_link_libraries(rt64 ${X11_LIBRARIES} ${X11_Xrandr_LIB})
 endif()
 
 preprocess_shader(rt64 "src/shaders/RasterPS.hlsl")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,7 +351,7 @@ endif()
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     find_package(X11 REQUIRED)
     target_include_directories(rt64 PUBLIC ${X11_INCLUDE_DIR})
-    target_link_libraries(rt64 ${X11_LIBRARIES})
+    target_link_libraries(rt64 ${X11_LIBRARIES} Xrandr)
 endif()
 
 preprocess_shader(rt64 "src/shaders/RasterPS.hlsl")


### PR DESCRIPTION
This library is used for `XRRGetScreenResources`.

If it is not explicitly used then you get errors like this

```
/usr/bin/ld: /usr/lib/libXrandr.so: error adding symbols: DSO missing from command line
```