### PR TITLE
Fix a libxrandr memory leak

### DIFF
--- a/src/hle/rt64_application_window.cpp
+++ b/src/hle/rt64_application_window.cpp
@@ -251,10 +251,12 @@ namespace RT64 {
             if ((crtcInfo != nullptr) && (crtcInfo->mode != 0L)) {
                 activeModeID = crtcInfo->mode; 
             }
+            XRRFreeCrtcInfo(crtcInfo);
         }
 
         if (activeModeID == 0L) {
             fprintf(stderr, "Unable to find active mode through XRRGetScreenResources and XRRGetCrtcInfo.\n");
+            XRRFreeScreenResources(screenResources);
             return;
         }
 
@@ -265,6 +267,8 @@ namespace RT64 {
                 break;
             }
         }
+
+        XRRFreeScreenResources(screenResources);
 #   endif
     }
 


### PR DESCRIPTION
The `XRRGetScreenResources` and `XRRGetCrtcInfo` functions do dynamically allocate memory which should be freed with `XRRFreeScreenResources` and `XRRFreeCrtcInfo` respectively.

I noticed this because I was hunting a different issue and noticed ASAN started complaining about this. I had to dug into the libxrandr source code to figure out that those functions do dynamic allocations and the return value should be freed.

This is a pretty minor issue. On my testing the wasted memory was 3388 bytes. But since I already figured out how to solve this issue I thought why not upstream it.