### PR TITLE
Ubershader Optimizations

### DIFF
--- a/src/shaders/TextureDecoder.hlsli
+++ b/src/shaders/TextureDecoder.hlsli
@@ -6,6 +6,7 @@
 
 #include "Formats.hlsli"
 
+#include "shared/rt64_hlsl.h"
 #include "shared/rt64_f3d_defines.h"
 
 #define RDP_TMEM_BYTES 0x1000
@@ -27,37 +28,24 @@ uint implLoadTMEM(uint relativeAddress, uint maskAddress, uint orAddress, bool o
     }
 }
 
-#define loadOddRow(yCoord) const bool oddRow = (yCoord & 1)
 #define loadTMEM(relativeAddress) implLoadTMEM(relativeAddress, RDP_TMEM_MASK8, 0x0, oddRow, address, stride, TMEM)
 #define loadTMEMLower(relativeAddress) implLoadTMEM(relativeAddress, RDP_TMEM_MASK16, 0x0, oddRow, address, stride, TMEM)
 #define loadTMEMUpper(relativeAddress) implLoadTMEM(relativeAddress, RDP_TMEM_MASK16, (RDP_TMEM_BYTES >> 1), oddRow, address, stride, TMEM)
 #define loadTLUT(paletteAddress) TMEM.Load(uint2((paletteAddress) & RDP_TMEM_MASK8, 0))
 
-float4 sampleTMEMIA4(int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
-    loadOddRow(texelInt.y);
-    const uint pixelAddress = texelInt.y * stride + (texelInt.x / 2);
-    const bool oddColumn = (texelInt.x & 1);
-    const uint pixelValue = loadTMEM(pixelAddress);
+float4 sampleTMEMIA4(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelValue0, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
     const uint pixelShift = oddColumn ? 0 : 4;
-    return IA4ToFloat4((pixelValue >> pixelShift) & 0xF);
+    return IA4ToFloat4((pixelValue0 >> pixelShift) & 0xF);
 }
 
-float4 sampleTMEMI4(int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
-    loadOddRow(texelInt.y);
-    const uint pixelAddress = texelInt.y * stride + (texelInt.x / 2);
-    const bool oddColumn = (texelInt.x & 1);
-    const uint pixelValue = loadTMEM(pixelAddress);
+float4 sampleTMEMI4(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelValue0, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
     const uint pixelShift = oddColumn ? 0 : 4;
-    return I4ToFloat4((pixelValue >> pixelShift) & 0xF);
+    return I4ToFloat4((pixelValue0 >> pixelShift) & 0xF);
 }
 
-float4 sampleTMEMCI4TLUT(int2 texelInt, uint address, uint stride, uint tlut, uint palette, Texture1D<uint> TMEM) {
-    loadOddRow(texelInt.y);
-    const uint pixelAddress = texelInt.y * stride + (texelInt.x / 2);
-    const bool oddColumn = (texelInt.x & 1);
-    const uint pixelValue = loadTMEM(pixelAddress);
+float4 sampleTMEMCI4TLUT(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelValue0, int2 texelInt, uint address, uint stride, uint tlut, uint palette, Texture1D<uint> TMEM) {
     const uint pixelShift = oddColumn ? 0 : 4;
-    const uint paletteAddress = RDP_TMEM_PALETTE + (palette << 7) + (((pixelValue >> pixelShift) & 0xF) << 3);
+    const uint paletteAddress = RDP_TMEM_PALETTE + (palette << 7) + (((pixelValue0 >> pixelShift) & 0xF) << 3);
     const uint paletteValue = loadTLUT(paletteAddress + 1) | (loadTLUT(paletteAddress) << 8);
     switch (tlut) {
     case G_TT_RGBA16:
@@ -69,55 +57,42 @@ float4 sampleTMEMCI4TLUT(int2 texelInt, uint address, uint stride, uint tlut, ui
     }
 }
 
-float4 sampleTMEMCI4(int2 texelInt, uint address, uint stride, uint palette, Texture1D<uint> TMEM) {
+float4 sampleTMEMCI4(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelValue0, int2 texelInt, uint address, uint stride, uint palette, Texture1D<uint> TMEM) {
     // Not a real format. Loads the palette index as the upper bits of the value.
-    loadOddRow(texelInt.y);
-    const uint pixelAddress = texelInt.y * stride + (texelInt.x / 2);
-    const bool oddColumn = (texelInt.x & 1);
-    const uint pixelValue = loadTMEM(pixelAddress);
     const uint pixelShift = oddColumn ? 0 : 4;
-    const uint paletteIndex = (pixelValue >> pixelShift) & 0xF;
+    const uint paletteIndex = (pixelValue0 >> pixelShift) & 0xF;
     const uint decodedValue = (palette << 4) | paletteIndex;
     return I8ToFloat4(decodedValue);
 }
 
-float4 sampleTMEM4b(int2 texelInt, uint fmt, uint address, uint stride, uint palette, Texture1D<uint> TMEM) {
+float4 sampleTMEM4b(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelValue0, int2 texelInt, uint fmt, uint address, uint stride, uint palette, Texture1D<uint> TMEM) {
     switch (fmt) {
     // Not a real format. Replicated by observing hardware behavior.
     case G_IM_FMT_RGBA:
-        return sampleTMEMI4(texelInt, address, stride, TMEM);
+        return sampleTMEMI4(oddRow, oddColumn, pixelAddress, pixelValue0, texelInt, address, stride, TMEM);
     case G_IM_FMT_YUV:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
     case G_IM_FMT_CI:
-        return sampleTMEMCI4(texelInt, address, stride, palette, TMEM);
+        return sampleTMEMCI4(oddRow, oddColumn, pixelAddress, pixelValue0, texelInt, address, stride, palette, TMEM);
     case G_IM_FMT_IA:
-        return sampleTMEMIA4(texelInt, address, stride, TMEM);
+        return sampleTMEMIA4(oddRow, oddColumn, pixelAddress, pixelValue0, texelInt, address, stride, TMEM);
     case G_IM_FMT_I:
-        return sampleTMEMI4(texelInt, address, stride, TMEM);
+        return sampleTMEMI4(oddRow, oddColumn, pixelAddress, pixelValue0, texelInt, address, stride, TMEM);
     default:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
     }
 }
 
-float4 sampleTMEMIA8(int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
-    loadOddRow(texelInt.y);
-    const uint pixelAddress = texelInt.y * stride + texelInt.x;
-    const uint pixelValue = loadTMEM(pixelAddress);
-    return IA8ToFloat4(pixelValue);
+float4 sampleTMEMIA8(bool oddRow, uint pixelAddress, uint pixelValue0, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
+    return IA8ToFloat4(pixelValue0);
 }
 
-float4 sampleTMEMI8(int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
-    loadOddRow(texelInt.y);
-    const uint pixelAddress = texelInt.y * stride + texelInt.x;
-    const uint pixelValue = loadTMEM(pixelAddress);
-    return I8ToFloat4(pixelValue);
+float4 sampleTMEMI8(bool oddRow, uint pixelAddress, uint pixelValue0, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
+    return I8ToFloat4(pixelValue0);
 }
 
-float4 sampleTMEMCI8(int2 texelInt, uint address, uint stride, uint tlut, Texture1D<uint> TMEM) {
-    loadOddRow(texelInt.y);
-    const uint pixelAddress = texelInt.y * stride + texelInt.x;
-    const uint pixelValue = loadTMEM(pixelAddress);
-    const uint paletteAddress = RDP_TMEM_PALETTE + (pixelValue << 3);
+float4 sampleTMEMCI8(bool oddRow, uint pixelAddress, uint pixelValue0, int2 texelInt, uint address, uint stride, uint tlut, Texture1D<uint> TMEM) {
+    const uint paletteAddress = RDP_TMEM_PALETTE + (pixelValue0 << 3);
     const uint paletteValue = loadTLUT(paletteAddress + 1) | (loadTLUT(paletteAddress) << 8);
     switch (tlut) {
     case G_TT_RGBA16:
@@ -129,49 +104,43 @@ float4 sampleTMEMCI8(int2 texelInt, uint address, uint stride, uint tlut, Textur
     }
 }
 
-float4 sampleTMEM8b(int2 texelInt, uint fmt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEM8b(bool oddRow, uint pixelAddress, uint pixelValue0, int2 texelInt, uint fmt, uint address, uint stride, Texture1D<uint> TMEM) {
     switch (fmt) {
         // Not a real format. Replicated by observing hardware behavior.
     case G_IM_FMT_RGBA:
-        return sampleTMEMI8(texelInt, address, stride, TMEM);
+        return sampleTMEMI8(oddRow, pixelAddress, pixelValue0, texelInt, address, stride, TMEM);
     case G_IM_FMT_YUV:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
         // CI behaves like I when a TLUT is not active.
     case G_IM_FMT_CI:
-        return sampleTMEMI8(texelInt, address, stride, TMEM);
+        return sampleTMEMI8(oddRow, pixelAddress, pixelValue0, texelInt, address, stride, TMEM);
     case G_IM_FMT_IA:
-        return sampleTMEMIA8(texelInt, address, stride, TMEM);
+        return sampleTMEMIA8(oddRow, pixelAddress, pixelValue0, texelInt, address, stride, TMEM);
     case G_IM_FMT_I:
-        return sampleTMEMI8(texelInt, address, stride, TMEM);
+        return sampleTMEMI8(oddRow, pixelAddress, pixelValue0, texelInt, address, stride, TMEM);
     default:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
     }
 }
 
-float4 sampleTMEMRGBA16(int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
-    loadOddRow(texelInt.y);
-    const uint pixelAddress = texelInt.y * stride + texelInt.x * 2;
-    const uint col16 = loadTMEM(pixelAddress + 1) | (loadTMEM(pixelAddress) << 8);
+float4 sampleTMEMRGBA16(bool oddRow, uint pixelAddress, uint pixelValue0, uint pixelValue1, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
+    const uint col16 = pixelValue1 | (pixelValue0 << 8);
     return RGBA16ToFloat4(col16);
 }
 
-float4 sampleTMEMIA16(int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
-    loadOddRow(texelInt.y);
-    const uint pixelAddress = texelInt.y * stride + texelInt.x * 2;
-    const uint ia16 = loadTMEM(pixelAddress + 1) | (loadTMEM(pixelAddress) << 8);
+float4 sampleTMEMIA16(bool oddRow, uint pixelAddress, uint pixelValue0, uint pixelValue1, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
+    const uint ia16 = pixelValue1 | (pixelValue0 << 8);
     return IA16ToFloat4(ia16);
 }
 
-float4 sampleTMEMI16(int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEMI16(bool oddRow, uint pixelAddress, uint pixelValue0, uint pixelValue1, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
     // Not a real format. The observed hardware behavior is replicated here by decoding as IA and storing it as IAIA.
-    loadOddRow(texelInt.y);
-    const uint pixelAddress = texelInt.y * stride + texelInt.x * 2;
-    const uint intensity = loadTMEM(pixelAddress);
-    const uint alpha = loadTMEM(pixelAddress + 1);
+    const uint intensity = pixelValue0;
+    const uint alpha = pixelValue1;
     return float4(intensity / 255.0f, alpha / 255.0f, intensity / 255.0f, alpha / 255.0f);
 }
 
-float4 sampleTMEMCI16(int2 texelInt, uint address, uint stride, uint tlut, Texture1D<uint> TMEM) {
+float4 sampleTMEMCI16(bool oddRow, uint pixelAddress, uint pixelValue0, uint pixelValue1, int2 texelInt, uint address, uint stride, uint tlut, Texture1D<uint> TMEM) {
     switch (tlut) {
     case G_TT_RGBA16:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
@@ -182,26 +151,24 @@ float4 sampleTMEMCI16(int2 texelInt, uint address, uint stride, uint tlut, Textu
     }
 }
 
-float4 sampleTMEM16b(int2 texelInt, uint fmt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEM16b(bool oddRow, uint pixelAddress, uint pixelValue0, uint pixelValue1, int2 texelInt, uint fmt, uint address, uint stride, Texture1D<uint> TMEM) {
     switch (fmt) {
     case G_IM_FMT_RGBA:
-        return sampleTMEMRGBA16(texelInt, address, stride, TMEM);
+        return sampleTMEMRGBA16(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, TMEM);
     case G_IM_FMT_YUV:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
     case G_IM_FMT_CI:
-        return sampleTMEMI16(texelInt, address, stride, TMEM);
+        return sampleTMEMI16(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, TMEM);
     case G_IM_FMT_IA:
-        return sampleTMEMIA16(texelInt, address, stride, TMEM);
+        return sampleTMEMIA16(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, TMEM);
     case G_IM_FMT_I:
-        return sampleTMEMI16(texelInt, address, stride, TMEM);
+        return sampleTMEMI16(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, TMEM);
     default:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
     }
 }
 
-float4 sampleTMEMRGBA32(int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
-    loadOddRow(texelInt.y);
-    const uint pixelAddress = texelInt.y * stride + texelInt.x * 2;
+float4 sampleTMEMRGBA32(bool oddRow, uint pixelAddress, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
     uint r = loadTMEMLower(pixelAddress);
     uint g = loadTMEMLower(pixelAddress + 1);
     uint b = loadTMEMUpper(pixelAddress);
@@ -209,15 +176,14 @@ float4 sampleTMEMRGBA32(int2 texelInt, uint address, uint stride, Texture1D<uint
     return RGBA32ToFloat4((r << 24) | (g << 16) | (b << 8) | a);
 }
 
-float4 sampleTMEMI32(int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEMI32(bool oddRow, uint pixelAddressDummy, uint pixelValue0, uint pixelValue1, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
     // Not a real format. The observed hardware behavior is replicated here by decoding
     // as RG as RGRG on even columns and BA as BABA on odd columns.
-    loadOddRow(texelInt.y);
     const bool oddColumn = (texelInt.x & 1);
     const uint pixelAddress = texelInt.y * stride + texelInt.x * 4;
     if (oddColumn) {
-        uint r = loadTMEM(pixelAddress);
-        uint g = loadTMEM(pixelAddress + 1);
+        uint r = pixelValue0;
+        uint g = pixelValue1;
         return float4(r / 255.0f, g / 255.0f, r / 255.0f, g / 255.0f);
     }
     else {
@@ -227,7 +193,7 @@ float4 sampleTMEMI32(int2 texelInt, uint address, uint stride, Texture1D<uint> T
     }
 }
 
-float4 sampleTMEMCI32(int2 texelInt, uint address, uint stride, uint tlut, Texture1D<uint> TMEM) {
+float4 sampleTMEMCI32(bool oddRow, uint pixelAddress, int2 texelInt, uint address, uint stride, uint tlut, Texture1D<uint> TMEM) {
     switch (tlut) {
     case G_TT_RGBA16:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
@@ -238,34 +204,45 @@ float4 sampleTMEMCI32(int2 texelInt, uint address, uint stride, uint tlut, Textu
     }
 }
 
-float4 sampleTMEM32b(int2 texelInt, uint fmt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEM32b(bool oddRow, uint pixelAddress, uint pixelValue0, uint pixelValue1, int2 texelInt, uint fmt, uint address, uint stride, Texture1D<uint> TMEM) {
     switch (fmt) {
     case G_IM_FMT_RGBA:
-        return sampleTMEMRGBA32(texelInt, address, stride, TMEM);
+        return sampleTMEMRGBA32(oddRow, pixelAddress, texelInt, address, stride, TMEM);
     case G_IM_FMT_YUV:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
     case G_IM_FMT_CI:
-        return sampleTMEMI32(texelInt, address, stride, TMEM);
+        return sampleTMEMI32(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, TMEM);
     case G_IM_FMT_IA:
-        return sampleTMEMI32(texelInt, address, stride, TMEM);
+        return sampleTMEMI32(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, TMEM);
     case G_IM_FMT_I:
-        return sampleTMEMI32(texelInt, address, stride, TMEM);
+        return sampleTMEMI32(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, TMEM);
     default:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
     }
 }
 
 float4 sampleTMEM(int2 texelInt, uint siz, uint fmt, uint address, uint stride, uint tlut, uint palette, Texture1D<uint> TMEM) {
+    const bool oddRow = (texelInt.y & 1);
+    const bool oddColumn = (texelInt.x & 1);
+    // Determine the left shift to use to calculate the tmem address. Effectively log2 of the column stride in half-bytes.
+    //   4-bit (siz 0) -> 0
+    //   8-bit (siz 1) -> 1
+    //   16-bit (siz 2) -> 2
+    //   32-bit (siz 2) -> 2 (32-bit textures sample both halves of tmem, so their stride is only half of their pixel bit width).
+    const uint tmemShift = select_uint(siz == G_IM_SIZ_32b, 2, siz);
+    const uint pixelAddress = texelInt.y * stride + ((texelInt.x << tmemShift) >> 1);
+    const uint pixelValue0 = loadTMEM(pixelAddress + 0);
+    const uint pixelValue1 = loadTMEM(pixelAddress + 1);
     if (tlut > 0) {
         switch (siz) {
         case G_IM_SIZ_4b:
-            return sampleTMEMCI4TLUT(texelInt, address, stride, tlut, palette, TMEM);
+            return sampleTMEMCI4TLUT(oddRow, oddColumn, pixelAddress, pixelValue0, texelInt, address, stride, tlut, palette, TMEM);
         case G_IM_SIZ_8b:
-            return sampleTMEMCI8(texelInt, address, stride, tlut, TMEM);
+            return sampleTMEMCI8(oddRow, pixelAddress, pixelValue0, texelInt, address, stride, tlut, TMEM);
         case G_IM_SIZ_16b:
-            return sampleTMEMCI16(texelInt, address, stride, tlut, TMEM);
+            return sampleTMEMCI16(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, tlut, TMEM);
         case G_IM_SIZ_32b:
-            return sampleTMEMCI32(texelInt, address, stride, tlut, TMEM);
+            return sampleTMEMCI32(oddRow, pixelAddress, texelInt, address, stride, tlut, TMEM);
         default:
             return float4(0.0f, 0.0f, 0.0f, 1.0f);
         }
@@ -273,13 +250,13 @@ float4 sampleTMEM(int2 texelInt, uint siz, uint fmt, uint address, uint stride, 
     else {
         switch (siz) {
         case G_IM_SIZ_4b:
-            return sampleTMEM4b(texelInt, fmt, address, stride, palette, TMEM);
+            return sampleTMEM4b(oddRow, oddColumn, pixelAddress, pixelValue0, texelInt, fmt, address, stride, palette, TMEM);
         case G_IM_SIZ_8b:
-            return sampleTMEM8b(texelInt, fmt, address, stride, TMEM);
+            return sampleTMEM8b(oddRow, pixelAddress, pixelValue0, texelInt, fmt, address, stride, TMEM);
         case G_IM_SIZ_16b:
-            return sampleTMEM16b(texelInt, fmt, address, stride, TMEM);
+            return sampleTMEM16b(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, fmt, address, stride, TMEM);
         case G_IM_SIZ_32b:
-            return sampleTMEM32b(texelInt, fmt, address, stride, TMEM);
+            return sampleTMEM32b(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, fmt, address, stride, TMEM);
         default:
             return float4(0.0f, 0.0f, 0.0f, 1.0f);
         }

--- a/src/shaders/TextureDecoder.hlsli
+++ b/src/shaders/TextureDecoder.hlsli
@@ -15,17 +15,13 @@
 #define RDP_TMEM_MASK16 0x7FF
 
 uint implLoadTMEM(uint relativeAddress, uint maskAddress, uint orAddress, bool oddRow, uint textureStart, uint rowSize, Texture1D<uint> TMEM) {
-    if (oddRow) {
-        const uint rowStart = (relativeAddress / rowSize) * rowSize;
-        const uint wordIndex = (relativeAddress - rowStart) / 4;
-        const uint swapWordIndex = wordIndex ^ 1;
-        const uint finalAddress = textureStart + rowStart + (swapWordIndex * 4) + (relativeAddress & 0x3);
-        return TMEM.Load(int2(((finalAddress & maskAddress) | orAddress) & RDP_TMEM_MASK8, 0));
-    }
-    else {
-        const uint finalAddress = textureStart + relativeAddress;
-        return TMEM.Load(int2(((finalAddress & maskAddress) | orAddress) & RDP_TMEM_MASK8, 0));
-    }
+    const uint rowStart = (relativeAddress / rowSize) * rowSize;
+    const uint wordIndex = (relativeAddress - rowStart) / 4;
+    const uint swapWordIndex = wordIndex ^ 1;
+    const uint finalAddress = select_uint(oddRow,
+        textureStart + rowStart + (swapWordIndex * 4) + (relativeAddress & 0x3),
+        textureStart + relativeAddress);
+    return TMEM.Load(int2(((finalAddress & maskAddress) | orAddress) & RDP_TMEM_MASK8, 0));
 }
 
 #define loadTMEM(relativeAddress) implLoadTMEM(relativeAddress, RDP_TMEM_MASK8, 0x0, oddRow, address, stride, TMEM)
@@ -33,19 +29,16 @@ uint implLoadTMEM(uint relativeAddress, uint maskAddress, uint orAddress, bool o
 #define loadTMEMUpper(relativeAddress) implLoadTMEM(relativeAddress, RDP_TMEM_MASK16, (RDP_TMEM_BYTES >> 1), oddRow, address, stride, TMEM)
 #define loadTLUT(paletteAddress) TMEM.Load(uint2((paletteAddress) & RDP_TMEM_MASK8, 0))
 
-float4 sampleTMEMIA4(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelValue0, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
-    const uint pixelShift = oddColumn ? 0 : 4;
-    return IA4ToFloat4((pixelValue0 >> pixelShift) & 0xF);
+float4 sampleTMEMIA4(uint pixelValue4bit) {
+    return IA4ToFloat4(pixelValue4bit);
 }
 
-float4 sampleTMEMI4(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelValue0, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
-    const uint pixelShift = oddColumn ? 0 : 4;
-    return I4ToFloat4((pixelValue0 >> pixelShift) & 0xF);
+float4 sampleTMEMI4(uint pixelValue4bit) {
+    return I4ToFloat4(pixelValue4bit);
 }
 
-float4 sampleTMEMCI4TLUT(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelValue0, int2 texelInt, uint address, uint stride, uint tlut, uint palette, Texture1D<uint> TMEM) {
-    const uint pixelShift = oddColumn ? 0 : 4;
-    const uint paletteAddress = RDP_TMEM_PALETTE + (palette << 7) + (((pixelValue0 >> pixelShift) & 0xF) << 3);
+float4 sampleTMEMCI4TLUT(uint pixelValue4bit, uint tlut, uint palette, Texture1D<uint> TMEM) {
+    const uint paletteAddress = RDP_TMEM_PALETTE + (palette << 7) + ((pixelValue4bit) << 3);
     const uint paletteValue = loadTLUT(paletteAddress + 1) | (loadTLUT(paletteAddress) << 8);
     switch (tlut) {
     case G_TT_RGBA16:
@@ -57,41 +50,37 @@ float4 sampleTMEMCI4TLUT(bool oddRow, bool oddColumn, uint pixelAddress, uint pi
     }
 }
 
-float4 sampleTMEMCI4(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelValue0, int2 texelInt, uint address, uint stride, uint palette, Texture1D<uint> TMEM) {
+float4 sampleTMEMCI4(uint pixelValue4bit, uint palette) {
     // Not a real format. Loads the palette index as the upper bits of the value.
-    const uint pixelShift = oddColumn ? 0 : 4;
-    const uint paletteIndex = (pixelValue0 >> pixelShift) & 0xF;
+    const uint paletteIndex = pixelValue4bit;
     const uint decodedValue = (palette << 4) | paletteIndex;
     return I8ToFloat4(decodedValue);
 }
 
-float4 sampleTMEM4b(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelValue0, int2 texelInt, uint fmt, uint address, uint stride, uint palette, Texture1D<uint> TMEM) {
+float4 sampleTMEM4b(uint pixelValue4bit, uint fmt, uint palette) {
     switch (fmt) {
-    // Not a real format. Replicated by observing hardware behavior.
-    case G_IM_FMT_RGBA:
-        return sampleTMEMI4(oddRow, oddColumn, pixelAddress, pixelValue0, texelInt, address, stride, TMEM);
-    case G_IM_FMT_YUV:
-        return float4(0.0f, 0.0f, 0.0f, 1.0f);
     case G_IM_FMT_CI:
-        return sampleTMEMCI4(oddRow, oddColumn, pixelAddress, pixelValue0, texelInt, address, stride, palette, TMEM);
+        return sampleTMEMCI4(pixelValue4bit, palette);
     case G_IM_FMT_IA:
-        return sampleTMEMIA4(oddRow, oddColumn, pixelAddress, pixelValue0, texelInt, address, stride, TMEM);
+        return sampleTMEMIA4(pixelValue4bit);
     case G_IM_FMT_I:
-        return sampleTMEMI4(oddRow, oddColumn, pixelAddress, pixelValue0, texelInt, address, stride, TMEM);
+    case G_IM_FMT_RGBA: // Not a real format. Replicated by observing hardware behavior.
+        return sampleTMEMI4(pixelValue4bit);
+    case G_IM_FMT_YUV:
     default:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
     }
 }
 
-float4 sampleTMEMIA8(bool oddRow, uint pixelAddress, uint pixelValue0, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEMIA8(uint pixelValue0) {
     return IA8ToFloat4(pixelValue0);
 }
 
-float4 sampleTMEMI8(bool oddRow, uint pixelAddress, uint pixelValue0, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEMI8(uint pixelValue0) {
     return I8ToFloat4(pixelValue0);
 }
 
-float4 sampleTMEMCI8(bool oddRow, uint pixelAddress, uint pixelValue0, int2 texelInt, uint address, uint stride, uint tlut, Texture1D<uint> TMEM) {
+float4 sampleTMEMCI8(uint pixelValue0, uint tlut, Texture1D<uint> TMEM) {
     const uint paletteAddress = RDP_TMEM_PALETTE + (pixelValue0 << 3);
     const uint paletteValue = loadTLUT(paletteAddress + 1) | (loadTLUT(paletteAddress) << 8);
     switch (tlut) {
@@ -104,71 +93,62 @@ float4 sampleTMEMCI8(bool oddRow, uint pixelAddress, uint pixelValue0, int2 texe
     }
 }
 
-float4 sampleTMEM8b(bool oddRow, uint pixelAddress, uint pixelValue0, int2 texelInt, uint fmt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEM8b(uint pixelValue0, uint fmt) {
     switch (fmt) {
-        // Not a real format. Replicated by observing hardware behavior.
-    case G_IM_FMT_RGBA:
-        return sampleTMEMI8(oddRow, pixelAddress, pixelValue0, texelInt, address, stride, TMEM);
-    case G_IM_FMT_YUV:
-        return float4(0.0f, 0.0f, 0.0f, 1.0f);
-        // CI behaves like I when a TLUT is not active.
-    case G_IM_FMT_CI:
-        return sampleTMEMI8(oddRow, pixelAddress, pixelValue0, texelInt, address, stride, TMEM);
     case G_IM_FMT_IA:
-        return sampleTMEMIA8(oddRow, pixelAddress, pixelValue0, texelInt, address, stride, TMEM);
+        return sampleTMEMIA8(pixelValue0);
     case G_IM_FMT_I:
-        return sampleTMEMI8(oddRow, pixelAddress, pixelValue0, texelInt, address, stride, TMEM);
+    case G_IM_FMT_RGBA: // Not a real format. Replicated by observing hardware behavior.
+    case G_IM_FMT_CI: // CI behaves like I when a TLUT is not active.
+        return sampleTMEMI8(pixelValue0);
+    case G_IM_FMT_YUV:
     default:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
     }
 }
 
-float4 sampleTMEMRGBA16(bool oddRow, uint pixelAddress, uint pixelValue0, uint pixelValue1, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEMRGBA16(uint pixelValue0, uint pixelValue1) {
     const uint col16 = pixelValue1 | (pixelValue0 << 8);
     return RGBA16ToFloat4(col16);
 }
 
-float4 sampleTMEMIA16(bool oddRow, uint pixelAddress, uint pixelValue0, uint pixelValue1, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEMIA16(uint pixelValue0, uint pixelValue1) {
     const uint ia16 = pixelValue1 | (pixelValue0 << 8);
     return IA16ToFloat4(ia16);
 }
 
-float4 sampleTMEMI16(bool oddRow, uint pixelAddress, uint pixelValue0, uint pixelValue1, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEMI16(uint pixelValue0, uint pixelValue1) {
     // Not a real format. The observed hardware behavior is replicated here by decoding as IA and storing it as IAIA.
     const uint intensity = pixelValue0;
     const uint alpha = pixelValue1;
     return float4(intensity / 255.0f, alpha / 255.0f, intensity / 255.0f, alpha / 255.0f);
 }
 
-float4 sampleTMEMCI16(bool oddRow, uint pixelAddress, uint pixelValue0, uint pixelValue1, int2 texelInt, uint address, uint stride, uint tlut, Texture1D<uint> TMEM) {
+float4 sampleTMEMCI16(uint pixelValue0, uint tlut, Texture1D<uint> TMEM) {
     switch (tlut) {
     case G_TT_RGBA16:
-        return float4(0.0f, 0.0f, 0.0f, 1.0f);
     case G_TT_IA16:
-        return float4(0.0f, 0.0f, 0.0f, 1.0f);
     default:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
     }
 }
 
-float4 sampleTMEM16b(bool oddRow, uint pixelAddress, uint pixelValue0, uint pixelValue1, int2 texelInt, uint fmt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEM16b(uint pixelValue0, uint pixelValue1, uint fmt) {
     switch (fmt) {
     case G_IM_FMT_RGBA:
-        return sampleTMEMRGBA16(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, TMEM);
-    case G_IM_FMT_YUV:
-        return float4(0.0f, 0.0f, 0.0f, 1.0f);
-    case G_IM_FMT_CI:
-        return sampleTMEMI16(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, TMEM);
+        return sampleTMEMRGBA16(pixelValue0, pixelValue1);
     case G_IM_FMT_IA:
-        return sampleTMEMIA16(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, TMEM);
+        return sampleTMEMIA16(pixelValue0, pixelValue1);
+    case G_IM_FMT_CI:
     case G_IM_FMT_I:
-        return sampleTMEMI16(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, TMEM);
+        return sampleTMEMI16(pixelValue0, pixelValue1);
+    case G_IM_FMT_YUV:
     default:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
     }
 }
 
-float4 sampleTMEMRGBA32(bool oddRow, uint pixelAddress, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEMRGBA32(bool oddRow, uint pixelAddress, uint address, uint stride, Texture1D<uint> TMEM) {
     uint r = loadTMEMLower(pixelAddress);
     uint g = loadTMEMLower(pixelAddress + 1);
     uint b = loadTMEMUpper(pixelAddress);
@@ -176,46 +156,36 @@ float4 sampleTMEMRGBA32(bool oddRow, uint pixelAddress, int2 texelInt, uint addr
     return RGBA32ToFloat4((r << 24) | (g << 16) | (b << 8) | a);
 }
 
-float4 sampleTMEMI32(bool oddRow, uint pixelAddressDummy, uint pixelValue0, uint pixelValue1, int2 texelInt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEMI32(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelValue0, uint pixelValue1, uint address, uint stride, Texture1D<uint> TMEM) {
     // Not a real format. The observed hardware behavior is replicated here by decoding
     // as RG as RGRG on even columns and BA as BABA on odd columns.
-    const bool oddColumn = (texelInt.x & 1);
-    const uint pixelAddress = texelInt.y * stride + texelInt.x * 4;
-    if (oddColumn) {
-        uint r = pixelValue0;
-        uint g = pixelValue1;
-        return float4(r / 255.0f, g / 255.0f, r / 255.0f, g / 255.0f);
-    }
-    else {
-        uint b = loadTMEM(pixelAddress + 2);
-        uint a = loadTMEM(pixelAddress + 3);
-        return float4(b / 255.0f, a / 255.0f, b / 255.0f, a / 255.0f);
-    }
+    const uint r = pixelValue0;
+    const uint g = pixelValue1;
+    const uint b = loadTMEM(pixelAddress + 2);
+    const uint a = loadTMEM(pixelAddress + 3);
+    return select(oddColumn,
+        float4(r / 255.0f, g / 255.0f, r / 255.0f, g / 255.0f),
+        float4(b / 255.0f, a / 255.0f, b / 255.0f, a / 255.0f));
 }
 
-float4 sampleTMEMCI32(bool oddRow, uint pixelAddress, int2 texelInt, uint address, uint stride, uint tlut, Texture1D<uint> TMEM) {
+float4 sampleTMEMCI32(uint pixelValue0, uint tlut, Texture1D<uint> TMEM) {
     switch (tlut) {
     case G_TT_RGBA16:
-        return float4(0.0f, 0.0f, 0.0f, 1.0f);
     case G_TT_IA16:
-        return float4(0.0f, 0.0f, 0.0f, 1.0f);
     default:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
     }
 }
 
-float4 sampleTMEM32b(bool oddRow, uint pixelAddress, uint pixelValue0, uint pixelValue1, int2 texelInt, uint fmt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEM32b(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelValue0, uint pixelValue1, int2 texelInt, uint fmt, uint address, uint stride, Texture1D<uint> TMEM) {
     switch (fmt) {
     case G_IM_FMT_RGBA:
-        return sampleTMEMRGBA32(oddRow, pixelAddress, texelInt, address, stride, TMEM);
-    case G_IM_FMT_YUV:
-        return float4(0.0f, 0.0f, 0.0f, 1.0f);
+        return sampleTMEMRGBA32(oddRow, pixelAddress, address, stride, TMEM);
     case G_IM_FMT_CI:
-        return sampleTMEMI32(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, TMEM);
     case G_IM_FMT_IA:
-        return sampleTMEMI32(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, TMEM);
     case G_IM_FMT_I:
-        return sampleTMEMI32(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, TMEM);
+        return sampleTMEMI32(oddRow, oddColumn, pixelAddress, pixelValue0, pixelValue1, address, stride, TMEM);
+    case G_IM_FMT_YUV:
     default:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
     }
@@ -224,25 +194,29 @@ float4 sampleTMEM32b(bool oddRow, uint pixelAddress, uint pixelValue0, uint pixe
 float4 sampleTMEM(int2 texelInt, uint siz, uint fmt, uint address, uint stride, uint tlut, uint palette, Texture1D<uint> TMEM) {
     const bool oddRow = (texelInt.y & 1);
     const bool oddColumn = (texelInt.x & 1);
-    // Determine the left shift to use to calculate the tmem address. Effectively log2 of the column stride in half-bytes.
+    // Determine the left shift to use to calculate the tmem address. Effectively log2 of the pixel stride in half-bytes.
     //   4-bit (siz 0) -> 0
     //   8-bit (siz 1) -> 1
     //   16-bit (siz 2) -> 2
-    //   32-bit (siz 2) -> 2 (32-bit textures sample both halves of tmem, so their stride is only half of their pixel bit width).
-    const uint tmemShift = select_uint(siz == G_IM_SIZ_32b, 2, siz);
+    //   32-bit (siz 3) -> 3
+    //   RGBA32 (siz 3) -> 2 (32-bit RGBA textures sample both halves of TMEM, so their pixel stride is only 16 bits).
+    const uint tmemShift = select_uint(and(fmt == G_IM_FMT_RGBA, siz == G_IM_SIZ_32b), 2, siz);
     const uint pixelAddress = texelInt.y * stride + ((texelInt.x << tmemShift) >> 1);
     const uint pixelValue0 = loadTMEM(pixelAddress + 0);
     const uint pixelValue1 = loadTMEM(pixelAddress + 1);
+    // Calculate value for 4-bit formats.
+    const uint pixelShift = select_uint(oddColumn, 0, 4);
+    const uint pixelValue4bit = (pixelValue0 >> pixelShift) & 0xF;
     if (tlut > 0) {
         switch (siz) {
         case G_IM_SIZ_4b:
-            return sampleTMEMCI4TLUT(oddRow, oddColumn, pixelAddress, pixelValue0, texelInt, address, stride, tlut, palette, TMEM);
+            return sampleTMEMCI4TLUT(pixelValue4bit, tlut, palette, TMEM);
         case G_IM_SIZ_8b:
-            return sampleTMEMCI8(oddRow, pixelAddress, pixelValue0, texelInt, address, stride, tlut, TMEM);
+            return sampleTMEMCI8(pixelValue0, tlut, TMEM);
         case G_IM_SIZ_16b:
-            return sampleTMEMCI16(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, address, stride, tlut, TMEM);
+            return sampleTMEMCI16(pixelValue0, tlut, TMEM);
         case G_IM_SIZ_32b:
-            return sampleTMEMCI32(oddRow, pixelAddress, texelInt, address, stride, tlut, TMEM);
+            return sampleTMEMCI32(pixelValue0, tlut, TMEM);
         default:
             return float4(0.0f, 0.0f, 0.0f, 1.0f);
         }
@@ -250,13 +224,13 @@ float4 sampleTMEM(int2 texelInt, uint siz, uint fmt, uint address, uint stride, 
     else {
         switch (siz) {
         case G_IM_SIZ_4b:
-            return sampleTMEM4b(oddRow, oddColumn, pixelAddress, pixelValue0, texelInt, fmt, address, stride, palette, TMEM);
+            return sampleTMEM4b(pixelValue4bit, fmt, palette);
         case G_IM_SIZ_8b:
-            return sampleTMEM8b(oddRow, pixelAddress, pixelValue0, texelInt, fmt, address, stride, TMEM);
+            return sampleTMEM8b(pixelValue0, fmt);
         case G_IM_SIZ_16b:
-            return sampleTMEM16b(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, fmt, address, stride, TMEM);
+            return sampleTMEM16b(pixelValue0, pixelValue1, fmt);
         case G_IM_SIZ_32b:
-            return sampleTMEM32b(oddRow, pixelAddress, pixelValue0, pixelValue1, texelInt, fmt, address, stride, TMEM);
+            return sampleTMEM32b(oddRow, oddColumn, pixelAddress, pixelValue0, pixelValue1, texelInt, fmt, address, stride, TMEM);
         default:
             return float4(0.0f, 0.0f, 0.0f, 1.0f);
         }

--- a/src/shaders/TextureDecoder.hlsli
+++ b/src/shaders/TextureDecoder.hlsli
@@ -24,9 +24,7 @@ uint implLoadTMEM(uint relativeAddress, uint maskAddress, uint orAddress, bool o
     return TMEM.Load(int2(((finalAddress & maskAddress) | orAddress) & RDP_TMEM_MASK8, 0));
 }
 
-#define loadTMEM(relativeAddress) implLoadTMEM(relativeAddress, RDP_TMEM_MASK8, 0x0, oddRow, address, stride, TMEM)
-#define loadTMEMLower(relativeAddress) implLoadTMEM(relativeAddress, RDP_TMEM_MASK16, 0x0, oddRow, address, stride, TMEM)
-#define loadTMEMUpper(relativeAddress) implLoadTMEM(relativeAddress, RDP_TMEM_MASK16, (RDP_TMEM_BYTES >> 1), oddRow, address, stride, TMEM)
+#define loadTMEMMasked(relativeAddress, mask, orAddress) implLoadTMEM(relativeAddress, mask, orAddress, oddRow, address, stride, TMEM)
 #define loadTLUT(paletteAddress) TMEM.Load(uint2((paletteAddress) & RDP_TMEM_MASK8, 0))
 
 float4 sampleTMEMIA4(uint pixelValue4bit) {
@@ -35,19 +33,6 @@ float4 sampleTMEMIA4(uint pixelValue4bit) {
 
 float4 sampleTMEMI4(uint pixelValue4bit) {
     return I4ToFloat4(pixelValue4bit);
-}
-
-float4 sampleTMEMCI4TLUT(uint pixelValue4bit, uint tlut, uint palette, Texture1D<uint> TMEM) {
-    const uint paletteAddress = RDP_TMEM_PALETTE + (palette << 7) + ((pixelValue4bit) << 3);
-    const uint paletteValue = loadTLUT(paletteAddress + 1) | (loadTLUT(paletteAddress) << 8);
-    switch (tlut) {
-    case G_TT_RGBA16:
-        return RGBA16ToFloat4(paletteValue);
-    case G_TT_IA16:
-        return IA16ToFloat4(paletteValue);
-    default:
-        return float4(0.0f, 0.0f, 0.0f, 1.0f);
-    }
 }
 
 float4 sampleTMEMCI4(uint pixelValue4bit, uint palette) {
@@ -80,19 +65,6 @@ float4 sampleTMEMI8(uint pixelValue0) {
     return I8ToFloat4(pixelValue0);
 }
 
-float4 sampleTMEMCI8(uint pixelValue0, uint tlut, Texture1D<uint> TMEM) {
-    const uint paletteAddress = RDP_TMEM_PALETTE + (pixelValue0 << 3);
-    const uint paletteValue = loadTLUT(paletteAddress + 1) | (loadTLUT(paletteAddress) << 8);
-    switch (tlut) {
-    case G_TT_RGBA16:
-        return RGBA16ToFloat4(paletteValue);
-    case G_TT_IA16:
-        return IA16ToFloat4(paletteValue);
-    default:
-        return float4(0.0f, 0.0f, 0.0f, 1.0f);
-    }
-}
-
 float4 sampleTMEM8b(uint pixelValue0, uint fmt) {
     switch (fmt) {
     case G_IM_FMT_IA:
@@ -107,13 +79,13 @@ float4 sampleTMEM8b(uint pixelValue0, uint fmt) {
     }
 }
 
-float4 sampleTMEMRGBA16(uint pixelValue0, uint pixelValue1) {
-    const uint col16 = pixelValue1 | (pixelValue0 << 8);
+float4 sampleTMEMRGBA16(uint pixelValue16bit) {
+    const uint col16 = pixelValue16bit;
     return RGBA16ToFloat4(col16);
 }
 
-float4 sampleTMEMIA16(uint pixelValue0, uint pixelValue1) {
-    const uint ia16 = pixelValue1 | (pixelValue0 << 8);
+float4 sampleTMEMIA16(uint pixelValue16bit) {
+    const uint ia16 = pixelValue16bit;
     return IA16ToFloat4(ia16);
 }
 
@@ -124,7 +96,7 @@ float4 sampleTMEMI16(uint pixelValue0, uint pixelValue1) {
     return float4(intensity / 255.0f, alpha / 255.0f, intensity / 255.0f, alpha / 255.0f);
 }
 
-float4 sampleTMEMCI16(uint pixelValue0, uint tlut, Texture1D<uint> TMEM) {
+float4 sampleTMEMCI16(uint paletteValue, uint tlut) {
     switch (tlut) {
     case G_TT_RGBA16:
     case G_TT_IA16:
@@ -134,11 +106,12 @@ float4 sampleTMEMCI16(uint pixelValue0, uint tlut, Texture1D<uint> TMEM) {
 }
 
 float4 sampleTMEM16b(uint pixelValue0, uint pixelValue1, uint fmt) {
+    uint pixelValue16bit = pixelValue1 | (pixelValue0 << 8);
     switch (fmt) {
     case G_IM_FMT_RGBA:
-        return sampleTMEMRGBA16(pixelValue0, pixelValue1);
+        return sampleTMEMRGBA16(pixelValue16bit);
     case G_IM_FMT_IA:
-        return sampleTMEMIA16(pixelValue0, pixelValue1);
+        return sampleTMEMIA16(pixelValue16bit);
     case G_IM_FMT_CI:
     case G_IM_FMT_I:
         return sampleTMEMI16(pixelValue0, pixelValue1);
@@ -148,27 +121,27 @@ float4 sampleTMEM16b(uint pixelValue0, uint pixelValue1, uint fmt) {
     }
 }
 
-float4 sampleTMEMRGBA32(bool oddRow, uint pixelAddress, uint address, uint stride, Texture1D<uint> TMEM) {
-    uint r = loadTMEMLower(pixelAddress);
-    uint g = loadTMEMLower(pixelAddress + 1);
-    uint b = loadTMEMUpper(pixelAddress);
-    uint a = loadTMEMUpper(pixelAddress + 1);
+float4 sampleTMEMRGBA32(uint pixelValue0, uint pixelValue1, uint pixelValue2, uint pixelValue3) {
+    uint r = pixelValue0;
+    uint g = pixelValue1;
+    uint b = pixelValue2;
+    uint a = pixelValue3;
     return RGBA32ToFloat4((r << 24) | (g << 16) | (b << 8) | a);
 }
 
-float4 sampleTMEMI32(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelValue0, uint pixelValue1, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEMI32(bool oddColumn, uint pixelValue0, uint pixelValue1, uint pixelValue2, uint pixelValue3) {
     // Not a real format. The observed hardware behavior is replicated here by decoding
     // as RG as RGRG on even columns and BA as BABA on odd columns.
     const uint r = pixelValue0;
     const uint g = pixelValue1;
-    const uint b = loadTMEM(pixelAddress + 2);
-    const uint a = loadTMEM(pixelAddress + 3);
+    const uint b = pixelValue2;
+    const uint a = pixelValue3;
     return select(oddColumn,
         float4(r / 255.0f, g / 255.0f, r / 255.0f, g / 255.0f),
         float4(b / 255.0f, a / 255.0f, b / 255.0f, a / 255.0f));
 }
 
-float4 sampleTMEMCI32(uint pixelValue0, uint tlut, Texture1D<uint> TMEM) {
+float4 sampleTMEMCI32(uint paletteValue, uint tlut) {
     switch (tlut) {
     case G_TT_RGBA16:
     case G_TT_IA16:
@@ -177,14 +150,14 @@ float4 sampleTMEMCI32(uint pixelValue0, uint tlut, Texture1D<uint> TMEM) {
     }
 }
 
-float4 sampleTMEM32b(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelValue0, uint pixelValue1, int2 texelInt, uint fmt, uint address, uint stride, Texture1D<uint> TMEM) {
+float4 sampleTMEM32b(bool oddColumn, uint pixelValue0, uint pixelValue1, uint pixelValue2, uint pixelValue3, uint fmt) {
     switch (fmt) {
     case G_IM_FMT_RGBA:
-        return sampleTMEMRGBA32(oddRow, pixelAddress, address, stride, TMEM);
+        return sampleTMEMRGBA32(pixelValue0, pixelValue1, pixelValue2, pixelValue3);
     case G_IM_FMT_CI:
     case G_IM_FMT_IA:
     case G_IM_FMT_I:
-        return sampleTMEMI32(oddRow, oddColumn, pixelAddress, pixelValue0, pixelValue1, address, stride, TMEM);
+        return sampleTMEMI32(oddColumn, pixelValue0, pixelValue1, pixelValue2, pixelValue3);
     case G_IM_FMT_YUV:
     default:
         return float4(0.0f, 0.0f, 0.0f, 1.0f);
@@ -194,34 +167,60 @@ float4 sampleTMEM32b(bool oddRow, bool oddColumn, uint pixelAddress, uint pixelV
 float4 sampleTMEM(int2 texelInt, uint siz, uint fmt, uint address, uint stride, uint tlut, uint palette, Texture1D<uint> TMEM) {
     const bool oddRow = (texelInt.y & 1);
     const bool oddColumn = (texelInt.x & 1);
-    // Determine the left shift to use to calculate the tmem address. Effectively log2 of the pixel stride in half-bytes.
+    const bool isRgba32 = and(fmt == G_IM_FMT_RGBA, siz == G_IM_SIZ_32b);
+    // Determine the left shift to use to calculate the TMEM address. Effectively log2 of the pixel stride in half-bytes.
     //   4-bit (siz 0) -> 0
     //   8-bit (siz 1) -> 1
     //   16-bit (siz 2) -> 2
     //   32-bit (siz 3) -> 3
     //   RGBA32 (siz 3) -> 2 (32-bit RGBA textures sample both halves of TMEM, so their pixel stride is only 16 bits).
-    const uint tmemShift = select_uint(and(fmt == G_IM_FMT_RGBA, siz == G_IM_SIZ_32b), 2, siz);
+    const uint tmemShift = select_uint(isRgba32, 2, siz);
+
+    // Determin the TMEM address mask. Each sample in RGBA32 only addresses half of TMEM.
+    const uint addressMask = select_uint(isRgba32, RDP_TMEM_MASK16, RDP_TMEM_MASK8);
+
+    // Load the two low samples for most formats.
     const uint pixelAddress = texelInt.y * stride + ((texelInt.x << tmemShift) >> 1);
-    const uint pixelValue0 = loadTMEM(pixelAddress + 0);
-    const uint pixelValue1 = loadTMEM(pixelAddress + 1);
+    const uint pixelValue0 = loadTMEMMasked(pixelAddress + 0, addressMask, 0x0);
+    const uint pixelValue1 = loadTMEMMasked(pixelAddress + 1, addressMask, 0x0);
+
     // Calculate value for 4-bit formats.
     const uint pixelShift = select_uint(oddColumn, 0, 4);
     const uint pixelValue4bit = (pixelValue0 >> pixelShift) & 0xF;
+
     if (tlut > 0) {
+        // Determine the palette index and load the value from the palette.
+        const uint paletteAddress = select_uint(siz == G_IM_SIZ_4b,
+            RDP_TMEM_PALETTE + (palette << 7) + ((pixelValue4bit) << 3),
+            RDP_TMEM_PALETTE + (pixelValue0 << 3));
+        const uint paletteValue = loadTLUT(paletteAddress + 1) | (loadTLUT(paletteAddress) << 8);
+
         switch (siz) {
         case G_IM_SIZ_4b:
-            return sampleTMEMCI4TLUT(pixelValue4bit, tlut, palette, TMEM);
         case G_IM_SIZ_8b:
-            return sampleTMEMCI8(pixelValue0, tlut, TMEM);
+            switch (tlut) {
+            case G_TT_RGBA16:
+                return RGBA16ToFloat4(paletteValue);
+            case G_TT_IA16:
+                return IA16ToFloat4(paletteValue);
+            default:
+                return float4(0.0f, 0.0f, 0.0f, 1.0f);
+            }
         case G_IM_SIZ_16b:
-            return sampleTMEMCI16(pixelValue0, tlut, TMEM);
+            return sampleTMEMCI16(paletteValue, tlut);
         case G_IM_SIZ_32b:
-            return sampleTMEMCI32(pixelValue0, tlut, TMEM);
+            return sampleTMEMCI32(paletteValue, tlut);
         default:
             return float4(0.0f, 0.0f, 0.0f, 1.0f);
         }
     }
     else {
+        // Load the two high samples for 32-bit textures.
+        const uint pixelAddress2 = select_uint(isRgba32, pixelAddress, pixelAddress + 2);
+        const uint orAddress = select_uint(isRgba32, (RDP_TMEM_BYTES >> 1), 0);
+        const uint pixelValue2 = loadTMEMMasked(pixelAddress2 + 0, addressMask, orAddress);
+        const uint pixelValue3 = loadTMEMMasked(pixelAddress2 + 1, addressMask, orAddress);
+        
         switch (siz) {
         case G_IM_SIZ_4b:
             return sampleTMEM4b(pixelValue4bit, fmt, palette);
@@ -230,7 +229,7 @@ float4 sampleTMEM(int2 texelInt, uint siz, uint fmt, uint address, uint stride, 
         case G_IM_SIZ_16b:
             return sampleTMEM16b(pixelValue0, pixelValue1, fmt);
         case G_IM_SIZ_32b:
-            return sampleTMEM32b(oddRow, oddColumn, pixelAddress, pixelValue0, pixelValue1, texelInt, fmt, address, stride, TMEM);
+            return sampleTMEM32b(oddColumn, pixelValue0, pixelValue1, pixelValue2, pixelValue3, fmt);
         default:
             return float4(0.0f, 0.0f, 0.0f, 1.0f);
         }

--- a/src/shared/rt64_hlsl.h
+++ b/src/shared/rt64_hlsl.h
@@ -248,6 +248,15 @@ namespace interop {
         inline const float *operator[](int i) const { return m[i]; }
         static float4x4 identity() { return FLOAT4X4_IDENTITY; }
     };
+
+    // Wrappers for select to prevent implicit casting to float.
+    inline uint select_uint(bool cond, uint val1, uint val2) {
+        return cond ? val1 : val2;
+    }
+
+    inline int select_int(bool cond, int val1, int val2) {
+        return cond ? val1 : val2;
+    }
 };
 
 
@@ -256,5 +265,14 @@ namespace interop {
 #else
 
 #define constmethod
+
+// Wrappers for select to prevent implicit casting to float.
+uint select_uint(bool cond, uint val1, uint val2) {
+    return select(cond, val1, val2);
+}
+
+int select_int(bool cond, int val1, int val2) {
+    return select(cond, val1, val2);
+}
 
 #endif


### PR DESCRIPTION
This PR significantly reduces the ubershader size (985kB to 108kB for the SPIR-V ubershader) by doing two things:
1) Deduplicate logic and loads between the various formats and sizes in the TMEM sampling path. A lot of logic for determining the TMEM addresses to load was easily modified to fit all possible format/size combinations.
2) Move the calls to `sampleTextureLevel` and `clampWrapMirrorSample` into for loops to deduplicate their bodies. This is significant because the lowest level texture sampling code was present 24 times in the original shader. This is because there were 4 `clampWrapMirrorSample` calls in `sampleTextureLevel`, three `sampleTextureLevel` calls in `sampleTexture`, and two `sampleTexture` calls in `RasterPS` for a total of 4 * 3 * 2 = 24 copies.

On all drivers (Mesa in particular), this significantly reduces the ubershader PSO building time for RT64. On my laptop with an Intel iGPU with Mesa, RT64 went from never finishing the ubershader PSO (even after giving it 20 minutes to build), to 10 minutes after some of these optimizations, and eventually to effectively instant with these optimizations completed. A side bonus of these optimizations is a reduction in the size of RT64, which resulted in 7MB shaved off a recomp exe.

There is a very minor impact on ubershader performance from this change, but it also results in vastly improved shader link times which makes it more than worth it in my eyes. On my machine in the same scene, I got these frametimes:

D3D12:
* New:
  * Specialized - 3.1ms
  * Ubershaders = 10.0ms
  * HD Textures Specialized - 3.0ms
  * HD Textures Ubershaders - 7.0ms
* Old:
  * Specialized - 3.1ms
  * Ubershaders - 9.2ms
  * HD Textures Specialized - 3.0ms
  * HD Textures Ubershaders - 6.9ms
Vulkan:
* New:
  * Specialized - 3.0ms
  * Ubershaders - 10.7ms
  * HD Textures specialized - 3.1ms
  * HD Textures Ubershaders - 7.9ms
* Old:
  * Specialized - 3.0ms
  * Ubershaders - 10.0ms
  * HD Textures Specialized - 3.1ms
  * HD Textures Ubershaders - 7.8ms

Meanwhile, dxc shader linking time for specialized shaders was reduced from around 300ms to 50ms average per shader.