### PR TITLE
fix(metal): mark arg buffer as modified

### DIFF
--- a/src/metal/rt64_metal.cpp
+++ b/src/metal/rt64_metal.cpp
@@ -1559,6 +1559,10 @@ namespace RT64 {
                     assert(false && "Unsupported descriptor type.");
             }
         }
+        
+        if (argumentBuffer.mtl->storageMode() == MTL::StorageModeManaged) {
+            argumentBuffer.mtl->didModifyRange(NS::Range(argumentBuffer.offset, argumentBuffer.mtl->length() - argumentBuffer.offset));
+        }
 
         resourceEntries[descriptorIndex].resource = nativeResource;
         resourceEntries[descriptorIndex].type = descriptorType;


### PR DESCRIPTION
This was making the RHI test not work on non apple silicon GPUs