### PR TITLE
fix(metal): Fixes two instances of bad releases

### DIFF
--- a/src/metal/rt64_metal.cpp
+++ b/src/metal/rt64_metal.cpp
@@ -1842,11 +1842,6 @@ namespace RT64 {
 
     MetalCommandList::~MetalCommandList() {
         mtl->release();
-        indexBuffer->release();
-
-        for (MTL::Buffer *buffer : vertexBuffers) {
-            buffer->release();
-        }
     }
 
     void MetalCommandList::begin() {
@@ -2111,7 +2106,6 @@ namespace RT64 {
                 needsUpdate = i >= stateCache.lastVertexBuffers.size() || interfaceBuffer->mtl != stateCache.lastVertexBuffers[i] || newOffset != stateCache.lastVertexBufferOffsets[i] || newIndex != stateCache.lastVertexBufferIndices[i];
 
                 vertexBuffers[i] = interfaceBuffer->mtl;
-                vertexBuffers[i]->retain();
                 vertexBufferOffsets[i] = newOffset;
                 vertexBufferIndices[i] = newIndex;
             }

--- a/src/metal/rt64_metal.cpp
+++ b/src/metal/rt64_metal.cpp
@@ -2111,6 +2111,7 @@ namespace RT64 {
                 needsUpdate = i >= stateCache.lastVertexBuffers.size() || interfaceBuffer->mtl != stateCache.lastVertexBuffers[i] || newOffset != stateCache.lastVertexBufferOffsets[i] || newIndex != stateCache.lastVertexBufferIndices[i];
 
                 vertexBuffers[i] = interfaceBuffer->mtl;
+                vertexBuffers[i]->retain();
                 vertexBufferOffsets[i] = newOffset;
                 vertexBufferIndices[i] = newIndex;
             }
@@ -3098,7 +3099,6 @@ namespace RT64 {
         resolveTexturePipelineState->release();
         clearVertexFunction->release();
         clearColorFunction->release();
-        clearDepthFunction->release();
         clearDepthFunction->release();
         device->release();
         reusableBlitDescriptor->release();


### PR DESCRIPTION
- Retains in one place where we hold a reference that we later release.
- Fixes a double release in destructor