### PR TITLE
Bump MAX_BINDING_NUMBER to a higher limit

### DIFF
--- a/src/metal/rt64_metal.cpp
+++ b/src/metal/rt64_metal.cpp
@@ -862,7 +862,7 @@ namespace RT64 {
         NS::AutoreleasePool *releasePool = NS::AutoreleasePool::alloc()->init();
 
         // Initialize binding vector with -1 (invalid index)
-        bindingToIndex.resize(MAX_BINDING_NUMBER + 1, -1);
+        bindingToIndex.resize(MAX_BINDING_NUMBER, -1);
 
         // Pre-allocate vectors with known size
         const uint32_t totalDescriptors = desc.descriptorRangesCount + (desc.lastRangeIsBoundless ? desc.boundlessRangeSize : 0);

--- a/src/metal/rt64_metal.h
+++ b/src/metal/rt64_metal.h
@@ -32,7 +32,7 @@
 
 namespace RT64 {
     static constexpr size_t MAX_CLEAR_RECTS = 16;
-    static constexpr uint32_t MAX_BINDING_NUMBER = 64;
+    static constexpr uint32_t MAX_BINDING_NUMBER = 128;
     static constexpr size_t DESCRIPTOR_SET_MAX_INDEX = 8;
 
     struct MetalInterface;


### PR DESCRIPTION
We're starting to hit this limit on Zelda, so bumping it up