### PR TITLE
Metal: Use default StorageMode for buffers

### DIFF
--- a/src/metal/rt64_metal.cpp
+++ b/src/metal/rt64_metal.cpp
@@ -1020,7 +1020,11 @@ namespace RT64 {
 
     void MetalBuffer::unmap(uint32_t subresource, const RenderRange* writtenRange) {
         if (mtl->storageMode() == MTL::StorageModeManaged) {
-            mtl->didModifyRange(NS::Range(writtenRange->begin, writtenRange->end - writtenRange->begin));
+            if (writtenRange == nullptr) {
+                mtl->didModifyRange(NS::Range(0, desc.size));
+            } else {
+                mtl->didModifyRange(NS::Range(writtenRange->begin, writtenRange->end - writtenRange->begin));
+            }
         }
     }
 


### PR DESCRIPTION
Apple recommends using the default `0` which is `Shared` internally the driver does the right thing for discrete graphic cards (also tested on AMD discrete).