### PR TITLE
TMEM Hasher Version 5. Fixes hashing of garbage bytes in the palette that go unused

### DIFF
--- a/src/common/rt64_tmem_hasher.h
+++ b/src/common/rt64_tmem_hasher.h
@@ -6,7 +6,7 @@
 
 namespace RT64 {
     struct TMEMHasher {
-        static const uint32_t CurrentHashVersion = 3;
+        static const uint32_t CurrentHashVersion = 4;
 
         static bool needsToHashRowsIndividually(const LoadTile &loadTile, uint32_t width) {
             // When using 32-bit formats, TMEM contents are split in half in the lower and upper half, so the size per row is effectively
@@ -37,14 +37,36 @@ namespace RT64 {
             const uint32_t drawBytesTotal = (loadTile.line << 3) * (height - 1) + drawBytesPerRow;
             const uint32_t tmemMask = halfTMEM ? TMEMMask16 : TMEMMask8;
             const uint32_t tmemAddress = (loadTile.tmem << 3) & tmemMask;
-            auto hashTMEM = [&](uint32_t tmemBaseAddress, uint32_t tmemOrAddress, uint32_t byteCount) {
+            auto hashTMEM = [&](uint32_t tmemBaseAddress, uint32_t tmemOrAddress, uint32_t byteCount, bool oddRow) {
+                assert((tmemBaseAddress < tmemSize) && "Base address must be masked within the bounds of the TMEM size.");
+
                 // Too many bytes to hash in a single step. Wrap around TMEM and hash the rest.
                 if ((tmemBaseAddress + byteCount) > tmemSize) {
-                    const uint32_t firstBytes = std::min(byteCount, std::max(tmemSize - tmemBaseAddress, 0U));
+                    const uint32_t firstBytes = (tmemSize - tmemBaseAddress);
                     XXH3_64bits_update(&xxh3, &TMEM[tmemBaseAddress | tmemOrAddress], firstBytes);
-                    XXH3_64bits_update(&xxh3, &TMEM[tmemOrAddress], std::min(byteCount - firstBytes, tmemBaseAddress));
+
+                    // Start hashing from the start of TMEM.
+                    byteCount = std::min(byteCount - firstBytes, tmemBaseAddress);
+                    tmemBaseAddress = 0;
                 }
-                // Hash as normal.
+
+                // Version 4 fixes an error where odd row word swapping was not considered when hashing rows individually.
+                if (oddRow && (version >= 4)) {
+                    uint32_t wordCount = byteCount / 8;
+                    if (wordCount > 0) {
+                        XXH3_64bits_update(&xxh3, &TMEM[tmemBaseAddress | tmemOrAddress], wordCount * 8);
+                        tmemBaseAddress += wordCount * 8;
+                        byteCount -= wordCount * 8;
+                    }
+                    
+                    if (byteCount > 4) {
+                        XXH3_64bits_update(&xxh3, &TMEM[tmemBaseAddress | tmemOrAddress], byteCount - 4);
+                        XXH3_64bits_update(&xxh3, &TMEM[(tmemBaseAddress + 4) | tmemOrAddress], 4);
+                    }
+                    else if (byteCount > 0) {
+                        XXH3_64bits_update(&xxh3, &TMEM[(tmemBaseAddress + 4) | tmemOrAddress], byteCount);
+                    }
+                }
                 else {
                     XXH3_64bits_update(&xxh3, &TMEM[tmemBaseAddress | tmemOrAddress], byteCount);
                 }
@@ -54,20 +76,20 @@ namespace RT64 {
             if ((version >= 2) && TMEMHasher::needsToHashRowsIndividually(loadTile, width)) {
                 uint32_t tmemBytesPerRow = loadTile.line << 3;
                 for (uint32_t i = 0; i < height; i++) {
-                    hashTMEM((tmemAddress + i * tmemBytesPerRow) & tmemMask, 0x0, drawBytesPerRow);
+                    hashTMEM((tmemAddress + i * tmemBytesPerRow) & tmemMask, 0x0, drawBytesPerRow, i & 1);
                 }
 
                 if (RGBA32) {
                     for (uint32_t i = 0; i < height; i++) {
-                        hashTMEM((tmemAddress + i * tmemBytesPerRow) & tmemMask, tmemSize, drawBytesPerRow);
+                        hashTMEM((tmemAddress + i * tmemBytesPerRow) & tmemMask, tmemSize, drawBytesPerRow, i & 1);
                     }
                 }
             }
             else {
-                hashTMEM(tmemAddress, 0x0, drawBytesTotal);
+                hashTMEM(tmemAddress, 0x0, drawBytesTotal, false);
 
                 if (RGBA32) {
-                    hashTMEM(tmemAddress, tmemSize, drawBytesTotal);
+                    hashTMEM(tmemAddress, tmemSize, drawBytesTotal, false);
                 }
             }
 


### PR DESCRIPTION
Supersedes #130.

Fixes https://github.com/rt64/rt64/issues/128.
Fixes https://github.com/rt64/rt64/issues/113.
Fixes https://github.com/rt64/rt64/issues/132.