### PR TITLE
Improve frame pacing for manual target framerates

### DIFF
--- a/src/common/rt64_timer.cpp
+++ b/src/common/rt64_timer.cpp
@@ -2,6 +2,9 @@
 // RT64
 //
 
+#include <cmath>
+#include <thread>
+
 #include "rt64_timer.h"
 
 namespace RT64 {
@@ -16,5 +19,53 @@ namespace RT64 {
 
     int64_t Timer::deltaMicroseconds(const Timestamp t1, const Timestamp t2) {
         return std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
+    }
+
+    void Timer::preciseSleepUntil(const Timestamp endTime) {
+        auto startTime = std::chrono::high_resolution_clock::now();
+        int64_t remainingNanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count();
+        if (remainingNanoseconds < 0) {
+            return;
+        }
+        double remainingSeconds = remainingNanoseconds / 1'000'000'000.0;
+
+        // Duration of the fixed sleep, in nanoseconds.
+        constexpr int64_t fixedSleepDuration = 100'000;
+        // Number of standard deviations to use as the upper bounds for the duration estimate.
+        constexpr double estimateStddevCount = 2.0;
+
+        // Statistics to keep track of the actual fixed sleep performance.
+        thread_local double fixedSleepEstimate = fixedSleepDuration / 1'000'000'000.0;
+        thread_local double mean = fixedSleepDuration / 1'000'000'000.0;
+        thread_local double m2 = 0;
+        thread_local uint64_t fixedSleepTotalCount = 1;
+        
+        // If the duration left to sleep is at least twice that of the nanosleep interval, use nanosleeps until the duration is too short for them to fit.
+        auto waitStart = std::chrono::high_resolution_clock::now();
+        while (remainingSeconds > fixedSleepEstimate) {
+            // Perform a fixed sleep and measure the time that actually passed.
+            std::this_thread::sleep_for(std::chrono::nanoseconds(fixedSleepDuration));
+            auto afterSleep = std::chrono::high_resolution_clock::now();
+            double measuredDuration = (afterSleep - waitStart).count() / 1'000'000'000.0;
+
+            // Adjust the remaining time based on the real duration of the fixed sleep.
+            remainingSeconds -= measuredDuration;
+
+            fixedSleepTotalCount++;
+
+            // Update the fixed sleep statistics.
+            double delta = measuredDuration - mean;
+            mean += delta / fixedSleepTotalCount;
+            m2 += delta * (measuredDuration - mean);
+            double stddev = sqrt(m2 / (fixedSleepTotalCount - 1));
+            fixedSleepEstimate = mean + estimateStddevCount * stddev;
+
+            waitStart = afterSleep;
+        }
+
+        // Spin until the end time is reached.
+        {
+            while (std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - endTime).count() < 0);
+        }
     }
 };

--- a/src/common/rt64_timer.cpp
+++ b/src/common/rt64_timer.cpp
@@ -69,8 +69,6 @@ namespace RT64 {
         }
 
         // Spin until the end time is reached.
-        {
-            while (std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - endTime).count() < 0);
-        }
+        while (std::chrono::high_resolution_clock::now() < endTime);
     }
 };

--- a/src/common/rt64_timer.h
+++ b/src/common/rt64_timer.h
@@ -15,5 +15,7 @@ namespace RT64 {
         static void initialize();
         static Timestamp current();
         static int64_t deltaMicroseconds(const Timestamp t1, const Timestamp t2);
+        // Sleeps until the given timestamp by using a series of fixed-duration sleeps followed by spinning for the last bit of the duration.
+        static void preciseSleepUntil(const Timestamp endTime);
     };
 };

--- a/src/hle/rt64_present_queue.cpp
+++ b/src/hle/rt64_present_queue.cpp
@@ -386,18 +386,12 @@ namespace RT64 {
             }
 
             if (presentFrame && swapChainValid) {
+                Timestamp oldPresentTimestamp = presentTimestamp;
                 // Wait until the approximate time the next present should be at the current intended rate.
                 if ((presentTimestamp != Timestamp()) && (targetRate > 0) && (targetRate > viOriginalRate)) {
-                    Timestamp currentTimestamp = Timer::current();
-                    int64_t deltaMicro = Timer::deltaMicroseconds(presentTimestamp, currentTimestamp);
-                    int64_t targetRateMicro = 1000000 / targetRate;
-
-                    // The OS only provides about one millisecond of accuracy by default. Since we also
-                    // want to wait slightly less than the target time, we substract from it and wait 1
-                    // millisecond less than the floor of the micrseconds value.
-                    int64_t msToWait = (targetRateMicro - deltaMicro - 500) / 1000;
-                    if (msToWait > 1) {
-                        Thread::sleepMilliseconds(msToWait - 1);
+                    // Don't sleep if the target framerate is the refresh rate, as vsync will take care of it.
+                    if (targetRate != ext.sharedResources->swapChainRate) {
+                        Timer::preciseSleepUntil(presentTimestamp + std::chrono::nanoseconds(1'000'000'000 / targetRate));
                     }
                 }
 
@@ -406,9 +400,9 @@ namespace RT64 {
                 }
 
                 RenderCommandSemaphore *waitSemaphore = drawSemaphore.get();
+                presentTimestamp = Timer::current();
                 swapChainValid = ext.swapChain->present(swapChainIndex, &waitSemaphore, 1);
                 presentProfiler.logAndRestart();
-                presentTimestamp = Timer::current();
             }
         }
     }

--- a/src/hle/rt64_present_queue.cpp
+++ b/src/hle/rt64_present_queue.cpp
@@ -386,7 +386,6 @@ namespace RT64 {
             }
 
             if (presentFrame && swapChainValid) {
-                Timestamp oldPresentTimestamp = presentTimestamp;
                 // Wait until the approximate time the next present should be at the current intended rate.
                 if ((presentTimestamp != Timestamp()) && (targetRate > 0) && (targetRate > viOriginalRate)) {
                     // Don't sleep if the target framerate is equal or bigger than the refresh rate, as vsync will take care of it.

--- a/src/hle/rt64_present_queue.cpp
+++ b/src/hle/rt64_present_queue.cpp
@@ -389,8 +389,8 @@ namespace RT64 {
                 Timestamp oldPresentTimestamp = presentTimestamp;
                 // Wait until the approximate time the next present should be at the current intended rate.
                 if ((presentTimestamp != Timestamp()) && (targetRate > 0) && (targetRate > viOriginalRate)) {
-                    // Don't sleep if the target framerate is the refresh rate, as vsync will take care of it.
-                    if (targetRate != ext.sharedResources->swapChainRate) {
+                    // Don't sleep if the target framerate is equal or bigger than the refresh rate, as vsync will take care of it.
+                    if (targetRate < ext.sharedResources->swapChainRate) {
                         Timer::preciseSleepUntil(presentTimestamp + std::chrono::nanoseconds(1'000'000'000 / targetRate));
                     }
                 }


### PR DESCRIPTION
This changes the sleep for manual frame pacing to use a repeated fixed-duration sleep. The sleep's actual duration and the standard deviation of that duration is measured to adapt to the actual runtime environment, rather than assuming it always sleeps the target amount.

This also changes the present timestamp to be measured before calling present, which helps prevent external presentation bottlenecks that cause the present call to take longer than normal.