### PR TITLE
macOS: fix SDL memory leak on destruction

### DIFF
--- a/src/hle/rt64_application_window.cpp
+++ b/src/hle/rt64_application_window.cpp
@@ -37,6 +37,20 @@ namespace RT64 {
             HookedApplicationWindow = nullptr;
         }
 
+#   if defined(__APPLE__)
+        // Destroy the Metal view before destroying the window
+        if (metalView != nullptr) {
+            SDL_Metal_DestroyView(metalView);
+            metalView = nullptr;
+        }
+#   endif
+
+        // Cleanup SDL window
+        if (sdlWindow != nullptr) {
+            SDL_DestroyWindow(sdlWindow);
+            sdlWindow = nullptr;
+        }
+
 #   ifdef _WIN32
         if (windowHook != nullptr) {
             UnhookWindowsHookEx(windowHook);
@@ -154,8 +168,8 @@ namespace RT64 {
         windowHandle.window = wmInfo.info.x11.window;
 #   elif defined(__APPLE__)
         windowHandle.window = sdlWindow;
-        SDL_MetalView view = SDL_Metal_CreateView(sdlWindow);
-        windowHandle.view = SDL_Metal_GetLayer(view);
+        metalView = SDL_Metal_CreateView(sdlWindow);
+        windowHandle.view = SDL_Metal_GetLayer(metalView);
 #   else
         static_assert(false && "Unimplemented");
 #   endif

--- a/src/hle/rt64_application_window.h
+++ b/src/hle/rt64_application_window.h
@@ -45,6 +45,7 @@ namespace RT64 {
         RenderWindow windowHandle = {};
 #if defined(__APPLE__)
         std::unique_ptr<CocoaWindow> windowWrapper;
+        SDL_MetalView metalView = nullptr;
 #endif
         Listener *listener;
         uint32_t refreshRate = 0;


### PR DESCRIPTION
Destroy the SDL Metal view and main window on destruction to fix memory leak.