### PR TITLE
Perform far plane clipping manually on pixel shader to account for F3D bug.

### DIFF
--- a/src/shaders/RasterPS.hlsl
+++ b/src/shaders/RasterPS.hlsl
@@ -64,21 +64,29 @@ LIBRARY_EXPORT bool RasterPS(const RenderParams rp, float4 vertexPosition, float
     int2 pixelPosSeed = floor(vertexPosition.xy);
     uint randomSeed = initRand(FrParams.frameCount, instanceIndex * pixelPosSeed.y * pixelPosSeed.x, 16); // TODO: Review seed.
 
+    // The F3D family of microcodes has a bug where polygons are clipped earlier than expected despite the depth being computed
+    // in a wider range of values. Not accounting for this can lead to geometry showing up that should otherwise be invisible.
+    // This max range was determined by using a test ROM against an LLE implementation.
+    // FIXME: This should be turned off for non-F3D microcodes.
+    const bool simulateDepthClipF3D = true;
+    const float MaxDepth = simulateDepthClipF3D && !renderFlagRect(rp.flags) && !zSourcePrim ? (1022.0f / 1024.0f) : 1.0f;
+    
+    // FIXME: This can be implemented by checking feature support for the API and embedding the depth bounds into the pipeline.
+    const bool pipelineDepthBounds = false;
+    
     // Handle no-nearclipping by clamping the minimum depth and manually clipping above the maximum.
     if (depthClampNear) {
         // Since depth clip is disabled on the PSO so near clip can be ignored, we manually clip any values above the allowed depth.
-        if (vertexPosition.z > 1.0f) {
+        if (vertexPosition.z > MaxDepth) {
             return false;
         }
     }
-#ifdef DYNAMIC_RENDER_PARAMS
-    // We emulate depth clip on the dynamic version of the shader.
-    else {
-        if ((vertexPosition.z < 0.0f) || (vertexPosition.z > 1.0f)) {
+    // Do depth clipping manually on the fragment shader if pipeline's depth bounds are not being used due to lack of hardware support.
+    else if (!pipelineDepthBounds) {
+        if ((vertexPosition.z < 0.0f) || (vertexPosition.z > MaxDepth)) {
             return false;
         }
     }
-#endif
 
     if (depthDecal) {
         // Sample the depth buffer for this pixel to compare for the decal check.


### PR DESCRIPTION
Fixes https://github.com/rt64/rt64/issues/111.