### PR TITLE
Double the refresh rate if interlacing is detected on Windows

### DIFF
--- a/src/hle/rt64_application_window.cpp
+++ b/src/hle/rt64_application_window.cpp
@@ -265,7 +265,7 @@ namespace RT64 {
             return;
         }
 
-        refreshRate = displayMode.dmDisplayFrequency;
+        refreshRate = displayMode.dmDisplayFlags & DM_INTERLACED ? displayMode.dmDisplayFrequency * 2 : displayMode.dmDisplayFrequency;
 
         // FIXME: This function truncates refresh rates that'd otherwise round to the correct rate in most cases.
         // This hack will fix most common cases where refresh rates divisble by 10 are truncated to the wrong value.

--- a/src/hle/rt64_application_window.cpp
+++ b/src/hle/rt64_application_window.cpp
@@ -265,7 +265,13 @@ namespace RT64 {
             return;
         }
 
-        refreshRate = displayMode.dmDisplayFlags & DM_INTERLACED ? displayMode.dmDisplayFrequency * 2 : displayMode.dmDisplayFrequency;
+        if (displayMode.dmDisplayFlags & DM_INTERLACED) {
+            // Interlaced modes report the refresh rate as half of what the actual refresh rate is.
+            refreshRate = displayMode.dmDisplayFrequency * 2;
+        }
+        else {
+            refreshRate = displayMode.dmDisplayFrequency;
+        }
 
         // FIXME: This function truncates refresh rates that'd otherwise round to the correct rate in most cases.
         // This hack will fix most common cases where refresh rates divisble by 10 are truncated to the wrong value.


### PR DESCRIPTION
If Windows declares that interlacing is being used, double the refresh rate to match the real refresh rate.

I don't know whether this is needed on Linux. Maybe SDL already deals with it. We can deal with that later if needed. 

This has been verified to work already, see: https://github.com/Zelda64Recomp/Zelda64Recomp/issues/704#issuecomment-4416284262