### PR TITLE
remove VK_EXT_scalar_block_layout dependency requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ set(ANDROID_ABI arm64-v8a)
 # For DXC
 set (DXC_COMMON_OPTS "-I${PROJECT_SOURCE_DIR}/src")
 set (DXC_DXIL_OPTS "-Wno-ignored-attributes")
-set (DXC_SPV_OPTS "-spirv" "-fspv-target-env=vulkan1.0" "-fvk-use-dx-layout")
+set (DXC_SPV_OPTS "-spirv" "-fspv-target-env=vulkan1.0")
 set (DXC_LB_OPTS "${DXC_COMMON_OPTS}" "-D" "LIBRARY" "-T" "lib_6_3")
 set (DXC_PS_OPTS "${DXC_COMMON_OPTS}" "-E" "PSMain" "-T ps_6_3")
 set (DXC_VS_OPTS "${DXC_COMMON_OPTS}" "-E" "VSMain" "-T vs_6_3" "-fvk-invert-y")

--- a/src/render/rt64_shader_compiler.cpp
+++ b/src/render/rt64_shader_compiler.cpp
@@ -75,7 +75,6 @@ namespace RT64 {
             break;
         case RenderShaderFormat::SPIRV:
             arguments.push_back(L"-spirv");
-            arguments.push_back(L"-fvk-use-dx-layout");
 
             if (profile.find(L"vs") != std::wstring::npos) {
                 arguments.push_back(L"-fvk-invert-y");

--- a/src/shared/rt64_extra_params.h
+++ b/src/shared/rt64_extra_params.h
@@ -39,17 +39,18 @@ namespace interop {
         float roughnessFactor;
         float refractionFactor;
         float shadowCatcherFactor;
-        float3 specularColor;
         float specularExponent;
         float solidAlphaMultiplier;
         float shadowAlphaMultiplier;
+        float3 specularColor;
         float depthOrderBias;
-        float depthDecalBias;
-        float shadowRayBias;
         float3 selfLight;
-        uint lightGroupMaskBits;
+        float depthDecalBias;
         float4 diffuseColorMix;
+        float shadowRayBias;
+        uint lightGroupMaskBits;
         uint enabledAttributes;
+        uint _padEnd;
 
 #ifdef HLSL_CPU
         void applyExtraAttributes(const ExtraParams &src) {

--- a/src/shared/rt64_gpu_tile.h
+++ b/src/shared/rt64_gpu_tile.h
@@ -55,9 +55,12 @@ namespace interop {
         float2 tcScale;
         uint2 texelShift;
         uint2 texelMask;
-        uint textureIndex;
         float3 textureDimensions;
+        uint textureIndex;
         GPUTileFlags flags;
+        uint _padEnd0;
+        uint _padEnd1;
+        uint _padEnd2;
     };
 #ifdef HLSL_CPU
 };

--- a/src/shared/rt64_point_light.h
+++ b/src/shared/rt64_point_light.h
@@ -11,16 +11,16 @@ namespace interop {
 #endif
     struct PointLight {
         float3 position;
-        float3 direction;
-        float3 diffuseColor;
         float attenuationRadius;
+        float3 direction;
         float pointRadius;
+        float3 diffuseColor;
         float spotFalloffCosine;
         float spotMaxCosine;
-        float3 specularColor;
         float shadowOffset;
         float attenuationExponent;
         float flickerIntensity;
+        float3 specularColor;
         uint groupBits;
     };
 #ifdef HLSL_CPU

--- a/src/shared/rt64_raster_params.h
+++ b/src/shared/rt64_raster_params.h
@@ -11,7 +11,9 @@ namespace interop {
 #endif
     struct RasterParams {
         uint renderIndex;
-        uint3 padding;
+        uint _pad0;
+        uint _pad1;
+        uint _pad2;
         float2 screenScale;
         float2 screenOffset;
     };

--- a/src/shared/rt64_rdp_params.h
+++ b/src/shared/rt64_rdp_params.h
@@ -17,8 +17,10 @@ namespace interop {
         float4 fogColor;
         float4 blendColor;
         float3 keyCenter;
+        float _padKeyCenter;
         float3 keyScale;
         int convertK[6];
+        int _padEnd[3];
     };
 #ifdef HLSL_CPU
 };

--- a/src/shared/rt64_rsp_light.h
+++ b/src/shared/rt64_rsp_light.h
@@ -11,10 +11,10 @@ namespace interop {
 #endif
     struct RSPLight {
         float3 posDir;
-        float3 col;
-        float3 colc;
         uint kc;
+        float3 col;
         uint kl;
+        float3 colc;
         uint kq;
     };
 

--- a/src/shared/rt64_rsp_lookat.h
+++ b/src/shared/rt64_rsp_lookat.h
@@ -15,7 +15,9 @@ namespace interop {
 #endif
     struct RSPLookAt {
         float3 x;
+        float _pad1;
         float3 y;
+        float _pad2;
     };
 #ifdef HLSL_CPU
 };

--- a/src/shared/rt64_rsp_viewport.h
+++ b/src/shared/rt64_rsp_viewport.h
@@ -13,7 +13,9 @@ namespace interop {
 #endif
     struct RSPViewport {
         float3 scale;
+        float _padScale;
         float3 translate;
+        float _padTranslate;
 
         static RSPViewport identity() {
             RSPViewport viewport;


### PR DESCRIPTION
closes https://github.com/rt64/rt64/issues/23

I have tested this patch on my own build of BanjoRecomp, which had serious graphical corruption before this change (due to only having Vulkan 1.1 on nintendo switch 32.3.1 nvidia drivers and rt64 dropping the check for `VK_EXT_scalar_block_layout` during previous refactors, which allows recomps based on newer versions of this to run but with corruption on devices without `VK_EXT_scalar_block_layout` support). after this patch, there are no observed graphical issues.