### PR TITLE
fix(texture-cache): parse database bytes portably

### DIFF
--- a/src/render/rt64_texture_cache.cpp
+++ b/src/render/rt64_texture_cache.cpp
@@ -1515,7 +1515,8 @@ namespace RT64 {
                 if (fileSystems[i]->load(ReplacementDatabaseFilename, databaseBytes)) {
                     try {
                         ReplacementDatabase db;
-                        db = json::parse(databaseBytes.begin(), databaseBytes.end(), nullptr, true);
+                        const std::string databaseJson(reinterpret_cast<const char *>(databaseBytes.data()), databaseBytes.size());
+                        db = json::parse(databaseJson, nullptr, true);
 
                         if (db.config.hashVersion <= TMEMHasher::CurrentHashVersion) {
                             db.resolvePaths(fileSystems[i].get(), uint32_t(i), fileSystemResolvedPaths[i], false, nullptr, &fileSystemStreamSets[i]);


### PR DESCRIPTION
Fixes a build failure with newer `libc++` when parsing replacement database JSON from a `std::vector<uint8_t>` buffer.

`nlohmann::json`’s iterator parser attempts to instantiate `std::char_traits<unsigned char>` for the current byte iterator type, which is not provided by `libc++`. Convert the loaded bytes to a `std::string` before parsing so the parser receives a standard character input type.

Tested by building BanjoRecomp against this RT64 revision on macOS with AppleClang 17.