### PR TITLE
Fix device vendor output formatting in console log

### DIFF
--- a/src/hle/rt64_application.cpp
+++ b/src/hle/rt64_application.cpp
@@ -200,7 +200,7 @@ namespace RT64 {
         // Print device information to console.
         RenderDeviceDescription deviceDescription = device->getDescription();
         fprintf(stdout, "Device Name: %s\n", deviceDescription.name.c_str());
-        fprintf(stdout, "Device Vendor: 0x%X\n", deviceDescription.vendor);
+        fprintf(stdout, "Device Vendor: 0x%X\n", static_cast<unsigned int>(deviceDescription.vendor));
         fprintf(stdout, "Driver Version: 0x%" PRIx64 "\n", deviceDescription.driverVersion);
 
         // Detect if the application should use hardware resolve or not.


### PR DESCRIPTION
This pull request makes a minor change to the way the device vendor ID is printed to the console, ensuring it is cast to an unsigned integer before formatting.

* Console Output:
  * Casts `deviceDescription.vendor` to `unsigned int` in the `fprintf` call to ensure correct formatting when printing the device vendor ID.