### PR TITLE
Enable Retina support on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ add_subdirectory(src/contrib/zstd/build/cmake)
 if (CMAKE_SYSTEM_NAME MATCHES "Linux" AND RT64_SDL_WINDOW_VULKAN)
     set(PLUME_SDL_VULKAN_ENABLED TRUE)
 elseif (APPLE)
-    set(PLUME_APPLE_RETINA_ENABLED OFF)
+    set(PLUME_APPLE_RETINA_ENABLED ON)
 endif()
 
 add_subdirectory(src/contrib/plume)


### PR DESCRIPTION
Retina support was disabled as part of integrating Plume's option to configure it (6dc3d4d9d4b310843e803e979a6bbedffe2cdbe9).

I'm not sure why this was done, presumably it was breaking something. However my experience has been that it makes the experience on MacOS significantly worse. Specifically on the launcher.