### PR TITLE
Fix macOS Metal autorelease ownership on worker threads

### DIFF
--- a/src/hle/rt64_workload_queue.cpp
+++ b/src/hle/rt64_workload_queue.cpp
@@ -8,9 +8,38 @@
 
 #include "rt64_present_queue.h"
 
+#ifdef __APPLE__
+#   include <Foundation/NSAutoreleasePool.hpp>
+#endif
+
 #define ENABLE_HIGH_RESOLUTION_RENDERER 1
 
 namespace RT64 {
+    namespace {
+#ifdef __APPLE__
+        struct ScopedAutoreleasePool {
+            NS::AutoreleasePool *pool = nullptr;
+
+            ScopedAutoreleasePool() {
+                pool = NS::AutoreleasePool::alloc()->init();
+            }
+
+            ~ScopedAutoreleasePool() {
+                pool->drain();
+            }
+
+            ScopedAutoreleasePool(const ScopedAutoreleasePool &) = delete;
+            ScopedAutoreleasePool &operator=(const ScopedAutoreleasePool &) = delete;
+        };
+#else
+        struct ScopedAutoreleasePool {
+            ScopedAutoreleasePool() = default;
+            ScopedAutoreleasePool(const ScopedAutoreleasePool &) = delete;
+            ScopedAutoreleasePool &operator=(const ScopedAutoreleasePool &) = delete;
+        };
+#endif
+    }
+
     static const int ReferenceHeight = 240;
     static const int ReferenceInterlacedHeight = 480;
 
@@ -851,6 +880,7 @@ namespace RT64 {
 
     void WorkloadQueue::renderThreadLoop() {
         Thread::setCurrentThreadName("RT64 Workload");
+        ScopedAutoreleasePool threadPool;
 
         WorkloadConfiguration workloadConfig;
         int64_t logicalTicks = 0;
@@ -873,6 +903,7 @@ namespace RT64 {
             }
 
             if (processCursor >= 0) {
+                ScopedAutoreleasePool workloadPool;
                 std::unique_lock<std::mutex> threadLock(threadMutex);
                 Workload &workload = workloads[processCursor];
                 ext.presentQueue->waitForPresentId(workload.presentId);
@@ -1164,6 +1195,7 @@ namespace RT64 {
         // This workaround is not required if the driver is configured to be at the "Max Performance" power state.
 
         Thread::setCurrentThreadName("RT64 Idle");
+        ScopedAutoreleasePool threadPool;
 
         const ShaderRecord &idle = ext.shaderLibrary->idle;
         RenderCommandList *commandList = ext.workloadGraphicsWorker->commandList.get();
@@ -1176,6 +1208,7 @@ namespace RT64 {
             }
 
             if (threadsRunning) {
+                ScopedAutoreleasePool idlePool;
                 if (workerMutex.try_lock()) {
                     commandList->begin();
                     commandList->setPipeline(idle.pipeline.get());

--- a/src/metal/rt64_metal.cpp
+++ b/src/metal/rt64_metal.cpp
@@ -1847,13 +1847,18 @@ namespace RT64 {
     }
 
     MetalCommandList::~MetalCommandList() {
-        mtl->release();
+        if (mtl != nullptr) {
+            mtl->release();
+        }
     }
 
     void MetalCommandList::begin() {
         assert(mtl == nullptr);
+        NS::AutoreleasePool *releasePool = NS::AutoreleasePool::alloc()->init();
         mtl = queue->mtl->commandBufferWithUnretainedReferences();
         mtl->setLabel(MTLSTR("RT64 Command List"));
+        mtl->retain();
+        releasePool->release();
     }
 
     void MetalCommandList::end() {
@@ -2763,8 +2768,11 @@ namespace RT64 {
         activeType = EncoderType::Blit;
 
         if (activeBlitEncoder == nullptr) {
+            NS::AutoreleasePool *releasePool = NS::AutoreleasePool::alloc()->init();
             activeBlitEncoder = mtl->blitCommandEncoder(device->renderInterface->reusableBlitDescriptor);
             activeBlitEncoder->setLabel(MTLSTR("Copy Blit Encoder"));
+            activeBlitEncoder->retain();
+            releasePool->release();
         }
     }
 
@@ -2783,9 +2791,12 @@ namespace RT64 {
         activeType = EncoderType::Resolve;
 
         if (activeResolveComputeEncoder == nullptr) {
+            NS::AutoreleasePool *releasePool = NS::AutoreleasePool::alloc()->init();
             activeResolveComputeEncoder = mtl->computeCommandEncoder();
             activeResolveComputeEncoder->setLabel(MTLSTR("Resolve Texture Encoder"));
             activeResolveComputeEncoder->setComputePipelineState(device->renderInterface->resolveTexturePipelineState);
+            activeResolveComputeEncoder->retain();
+            releasePool->release();
         }
     }
 
@@ -2868,7 +2879,9 @@ namespace RT64 {
         assert(commandListCount > 0);
 
         // Create a new command buffer to encode the wait semaphores into
+        NS::AutoreleasePool *releasePool = NS::AutoreleasePool::alloc()->init();
         MTL::CommandBuffer* cmdBuffer = mtl->commandBufferWithUnretainedReferences();
+        cmdBuffer->retain();
         cmdBuffer->setLabel(MTLSTR("Wait Command Buffer"));
         cmdBuffer->enqueue();
 
@@ -2878,6 +2891,8 @@ namespace RT64 {
         }
 
         cmdBuffer->commit();
+        cmdBuffer->release();
+        releasePool->release();
 
         // Commit all command lists except the last one
 

--- a/src/metal/rt64_metal.cpp
+++ b/src/metal/rt64_metal.cpp
@@ -1058,8 +1058,6 @@ namespace RT64 {
         // Create texture with configured descriptor and alignment
         MTL::TextureDescriptor *descriptor = MTL::TextureDescriptor::textureBufferDescriptor(pixelFormat, width, options, usage);
         this->texture = buffer->mtl->newTexture(descriptor, 0, bytesPerRow);
-
-        descriptor->release();
     }
 
     MetalBufferFormattedView::~MetalBufferFormattedView() {
@@ -1173,7 +1171,7 @@ namespace RT64 {
         assert(format == RenderShaderFormat::METAL);
 
         this->format = format;
-        this->functionName = (entryPointName != nullptr) ? NS::String::string(entryPointName, NS::UTF8StringEncoding) : MTLSTR("");
+        this->functionName = NS::String::alloc()->init(entryPointName != nullptr ? entryPointName : "", NS::UTF8StringEncoding);
 
         NS::Error *error = nullptr;
         const dispatch_data_t dispatchData = dispatch_data_create(data, size, dispatch_get_main_queue(), ^{});


### PR DESCRIPTION
## Summary

This fixes macOS Metal object lifetime issues in the RT64 branch used by Zelda64Recomp.

Changes:
- retain command buffers and encoders returned by autoreleasing Metal methods before storing them past the current scope
- add scoped autorelease pools to the RT64 workload and idle worker thread loops on Apple platforms
- correct two Metal ownership mismatches: do not manually release the autoreleased texture buffer descriptor, and make MetalShader::functionName an owned NS::String because the destructor releases it

## Root cause

RT64 worker threads create autoreleased Objective-C and Metal objects. Those threads did not have stable autorelease pools, and some autoreleased Metal objects were stored or later released as if RT64 owned them. This can crash on macOS during RT64 worker teardown with EXC_BAD_ACCESS in objc_release / AutoreleasePoolPage::releaseUntil.

The per-thread pools make autorelease lifetimes correct, while the Metal ownership fixes prevent the pool drain from exposing over-release bugs.

## Base branch note

This is opened against fix-multimonitor-frame-pacing because the current RT64 main branch does not contain src/metal/rt64_metal.cpp. Zelda64Recomp currently pins the RT64 commit 23cab603c4f9f4a8b369b38e036f1aa484603878 from this branch.

## Validation

Validated through a Zelda64Recomp build using this RT64 branch:
- cmake --build build-test-app --target Zelda64Recompiled
- codesign --verify --deep --strict --verbose=2 build-test-app/Zelda64Recompiled.app
- manual macOS launch with the provided Majora's Mask ROM
- repeated Start Game attempts no longer crash
- clean exit no longer crashes

Observed failing reports before the fix triggered on RT64 Workload / RT64 Idle threads in objc_release while draining or tearing down autorelease state.