### PR TITLE
Fix hover highlighting in the debugger while paused

### DIFF
--- a/src/hle/rt64_state.cpp
+++ b/src/hle/rt64_state.cpp
@@ -1838,6 +1838,19 @@ namespace RT64 {
     void State::updateScreen(const VI &newVI, bool fromEarlyPresent) {
         // If the debugger has paused the plugin, keep submitting the last workload and screen VI for rendering and a present event.
         if (debuggerInspector.paused && !fromEarlyPresent) {
+            // Inspect the workload that is about to be RE-submitted, not the one
+            // the last unpaused frame left behind.
+            //
+            // lastWorkloadIndex is assigned writeCursor just before a workload is
+            // submitted, which is correct while running: the inspector writes
+            // debuggerDesc.highlightColor into that workload and it is then drawn,
+            // so hover highlighting works. While paused nothing new is submitted
+            // and repeatLastWorkload() re-renders previousWriteCursor() instead,
+            // so the inspector was painting a workload that is never drawn --
+            // hovering a framebuffer, projection or draw call in the paused
+            // debugger highlighted nothing at all.
+            lastWorkloadIndex = ext.workloadQueue->previousWriteCursor();
+
             if (ext.userConfig->developerMode) {
                 inspect();
             }


### PR DESCRIPTION
Hovering a framebuffer, projection or draw call in the debugger highlights nothing while the plugin is paused, though it works while running.

`lastWorkloadIndex` is assigned `writeCursor` immediately before a workload is submitted, which is correct on the running path: the inspector writes `debuggerDesc.highlightColor` into that workload and it is then drawn.

While paused nothing new is submitted, and `updateScreen` re-renders `previousWriteCursor()` via `repeatLastWorkload()`. `lastWorkloadIndex` still pointed at the workload the last unpaused frame left behind, so the inspector painted a workload that is never drawn and the highlight was invisible.

This points `lastWorkloadIndex` at the workload that is about to be re-submitted, before inspecting it.

Found while using the paused inspector to investigate geometry disappearing at the edges of a widened frame in an N64Recomp port, where being able to hover a draw call on a frozen frame is the whole point of pausing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ToqJWtRuSB5Nc4gYRx4tT